### PR TITLE
Make rscons compatible with Ruby 2.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,38 +2,42 @@ PATH
   remote: .
   specs:
     rscons (1.18.0)
+      e2mmap (>= 0.1.0)
       json (>= 1.8, < 3.0)
+      thwait (>= 0.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.3)
     docile (1.3.2)
-    json (2.2.0)
-    rake (13.0.0)
-    rdoc (6.2.0)
+    e2mmap (0.1.0)
+    json (2.3.0)
+    rake (13.0.1)
+    rdoc (6.2.1)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
       rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.0)
-      rspec-support (~> 3.9.0)
-    rspec-expectations (3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-support (3.9.0)
-    simplecov (0.17.1)
+    rspec-support (3.9.2)
+    simplecov (0.18.5)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
-    yard (0.9.20)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
+    thwait (0.1.0)
+    yard (0.9.24)
 
 PLATFORMS
   ruby
+  x64-mingw32
   x86-mingw32
 
 DEPENDENCIES

--- a/rscons.gemspec
+++ b/rscons.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "json", ">= 1.8", "< 3.0"
+  gem.add_dependency "e2mmap", ">= 0.1.0"
+  gem.add_dependency "thwait", ">= 0.1.0"
 
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
thwait and its dependency e2mmap are no longer bundled with Ruby.